### PR TITLE
Namespace: uniform namespace pve_lxc_* and pve hostname as an API variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [v3.0.0](https://github.com/UdelaRInterior/ansible-role-proxmox-create-lxc/tree/v3.0.0)
+
+* New interface with all role variables defined in the `pve_lxc_*` namespace. Update your host variables in your ansible code!
+* Backwards compatibility with [previous interface](https://github.com/UdelaRInterior/ansible-role-proxmox-create-lxc/blob/v2.2.0/README.md#role-variables) up to v4.X.Y release 
+
 ## [v2.2.0](https://github.com/UdelaRInterior/ansible-role-proxmox-create-lxc/tree/v2.2.0)
 
 * Now you can change the timeout for operations of the Ansible module `proxmox` according to the performance of your remote host. `proxmox_create_lxc_timeout` variable was added for this purpose.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v3.0.1](https://github.com/UdelaRInterior/ansible-role-proxmox-create-lxc/tree/v3.0.1)
+
+* missing namspace prefix and bad replacement that prevented setting any additional conf, 
+
 ## [v3.0.0](https://github.com/UdelaRInterior/ansible-role-proxmox-create-lxc/tree/v3.0.0)
 
 * New interface with all role variables defined in the `pve_lxc_*` namespace. Update your host variables in your ansible code!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Change Log
 
+## [v4.0.0](https://github.com/UdelaRInterior/ansible-role-proxmox-create-lxc/tree/v4.0.0)
+
+* End of v2.0.0 variables' API backward's compatibility, no longer needed and not considered clean code
+* The new variable's API no longer provides a default value of root's container password (`pve_lxc_root_password`) to avoid unsecure container creation 
+
 ## [v3.0.1](https://github.com/UdelaRInterior/ansible-role-proxmox-create-lxc/tree/v3.0.1)
 
-* missing namspace prefix and bad replacement that prevented setting any additional conf, 
+* missing namspace prefix and bad replacement that prevented setting any additional conf
 
 ## [v3.0.0](https://github.com/UdelaRInterior/ansible-role-proxmox-create-lxc/tree/v3.0.0)
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ pve_lxc_api_host: my_node.my_cluster.org
 pve_lxc_api_user: deploy@pam
 pve_lxc_node_deploy_password: D3pl0y_pwd
 pve_lxc_url_ostemplate: http://download.proxmox.com/images/system/debian-10.0-standard_10.0-1_amd64.tar.gz
+## to be enabled for ansible 2.10
 # pve_lxc_description: |
 #   Host is a test container. 
 #   Configured with onboot: no.

--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ New interface in v3.0.0, with all role variables defined in the `pve_lxc_*` name
 To give time to update your whole inventory, the role preserves backward compatibility with [previous interface](https://github.com/UdelaRInterior/ansible-role-proxmox-create-lxc/blob/v2.2.0/README.md#role-variables) up to v4.X.Y release. 
 
 ```yaml
-pve_lxc_hostname: "{{ inventory_hostname.split('.')[0] }}"
+pve_hostname: "{{ inventory_hostname.split('.')[0] }}"
 # By default, we suppose that `inventory_hostname` is the FQDN or the hostname of the host to create, so we set the variable to the hostname. 
 # You can arbitrarly define this hostname
 
-pve_lxc_node: my_node
-pve_lxc_api_host: my_node.my_cluster.org
-pve_lxc_api_user: deploy@pam
-pve_lxc_node_deploy_password: D3pl0y_pwd
+pve_node: my_node
+pve_api_host: my_node.my_cluster.org
+pve_api_user: deploy@pam
+pve_api_password: D3pl0y_pwd
 pve_lxc_url_ostemplate: http://download.proxmox.com/images/system/debian-10.0-standard_10.0-1_amd64.tar.gz
 ## to be enabled for ansible 2.10
 # pve_lxc_description: |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Ansible role proxmox_create_lxc
 
 [![Galaxy](https://img.shields.io/badge/galaxy-UdelaRInterior.proxmox__create__lxc-blue.svg)](https://galaxy.ansible.com/udelarinterior/proxmox_create_lxc) ![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/udelarinterior/ansible-role-proxmox-create-lxc?label=release&logo=github&style=social) ![GitHub stars](https://img.shields.io/github/stars/udelarinterior/ansible-role-proxmox-create-lxc?style=social) ![GitHub forks](https://img.shields.io/github/forks/udelarinterior/ansible-role-proxmox-create-lxc?style=social)
 
-A complete role for LXC container creation in a Proxmox Virtual Environement (PVE) cluster, with network fully configured and eventually several disks with acl and quotas management.
+A complete role for LXC container creation in a Proxmox Virtual Environement (PVE) cluster, with network fully configured and eventually several disks with acl and quotas management. The role wraps the [community `proxmox` collection](https://docs.ansible.com/ansible/latest/collections/community/general/proxmox_module.html#parameter-description)
 
 Requirements
 ------------
@@ -44,24 +44,28 @@ Role Variables
 The `defaults` variables define the container parameters. To be specified by host under `host_vars/host_fqdn/vars` and eventually encrypted in `host_vars/host_fqdn/vault`
 
 ```yaml
-node: my_node
-api_host: my_node.my_cluster.org
-api_user: deploy@pam
-node_deploy_password: D3pl0y_pwd
-url_ostemplate: http://download.proxmox.com/images/system/debian-10.0-standard_10.0-1_amd64.tar.gz
-unprivileged: true
-cores: 1
-cpu_limit: 1
-cpu_units: 1000
-memory: 512
-swap: 512
-disk: 32
-storage: local-lvm
-nameserver: 192.168.8.8 192.168.8.4
-root_password: 123testing1234
-onboot: no
+pve_lxc_hostname: "{{ inventory_hostname.split('.')[0] }}"
+# By default, we suppose that `inventory_hostname` is the FQDN or the hostname of the host to create, so we set the variable to the hostname. 
+# You can arbitrarly define this hostname
 
-net_interfaces:
+pve_lxc_node: my_node
+pve_lxc_api_host: my_node.my_cluster.org
+pve_lxc_api_user: deploy@pam
+pve_lxc_node_deploy_password: D3pl0y_pwd
+pve_lxc_url_ostemplate: http://download.proxmox.com/images/system/debian-10.0-standard_10.0-1_amd64.tar.gz
+pve_lxc_unprivileged: true
+pve_lxc_cores: 1
+pve_lxc_cpu_limit: 1
+pve_lxc_cpu_units: 1000
+pve_lxc_memory: 512
+pve_lxc_swap: 512
+pve_lxc_disk: 32
+pve_lxc_storage: local-lvm
+pve_lxc_nameserver: 192.168.8.8 192.168.8.4
+pve_lxc_root_password: 123testing1234
+pve_lxc_onboot: no
+
+pve_lxc_net_interfaces:
   - id: net0
     name: eth0
     hwaddr: F6:A2:69:61:94:8D
@@ -82,7 +86,7 @@ net_interfaces:
     netmask6: 64
     bridge: vmbr1
 
-mounts:
+pve_lxc_mounts:
   - id: mp0
     storage: local-lvm
     size: 16
@@ -98,10 +102,10 @@ mounts:
     mount_point: "/mnt/logs"
 
 # You can change the timeout for the operations of the module according to the performance of your remote host
-# proxmox_create_lxc_timeout: 30
+# pve_lxc_create_timeout: 30
 
 # Additional "manual" settings to add to the file /etc/pve/nodes/{{ node }}/lxc/{{ VMID }}.conf
-pve_additional_conf: []
+pve_lxc_additional_conf: []
         # Kernel modules available within the LXC
   # - 'mp0: /lib/modules/4.15.18-9-pve,mp=/lib/modules/4.15.18-9-pve,ro=1'
         # tun device for OpenVPN server inside LXC
@@ -138,7 +142,7 @@ the following playbook creates all the containers declared in the `pve_container
       roles:
         - create_lxc
 
-will create and start the containers, and configure root access with the `root_password` defined and the ssh key of your local machine (`~/.ssh/id_rsa.pub`).
+will create and start the containers, and configure root access with the `pve_lxc_root_password` defined and the ssh key of your local machine (`~/.ssh/id_rsa.pub`).
 
 BE CAREFULL: contrairly to debian standard installation, Proxmox container templates let remote root SSH open.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ $ git clone https://github.com/UdelaRInterior/ansible-role-proxmox-create-lxc.gi
 Role Variables
 --------------
 
-The `defaults` variables define the container parameters. To be specified by host under `host_vars/host_fqdn/vars` and eventually encrypted in `host_vars/host_fqdn/vault`
+The `defaults` variables define the container parameters. To be specified by host under `host_vars/host_fqdn/vars` and eventually encrypted in `host_vars/host_fqdn/vault`.
+
+New interface in v3.0.0, with all role variables defined in the `pve_lxc_*` namespace. Update your host variables in your ansible code!
+
+To give time to update your whole inventory, the role preserves backward compatibility with [previous interface](https://github.com/UdelaRInterior/ansible-role-proxmox-create-lxc/blob/v2.2.0/README.md#role-variables) up to v4.X.Y release. 
 
 ```yaml
 pve_lxc_hostname: "{{ inventory_hostname.split('.')[0] }}"
@@ -53,6 +57,9 @@ pve_lxc_api_host: my_node.my_cluster.org
 pve_lxc_api_user: deploy@pam
 pve_lxc_node_deploy_password: D3pl0y_pwd
 pve_lxc_url_ostemplate: http://download.proxmox.com/images/system/debian-10.0-standard_10.0-1_amd64.tar.gz
+# pve_lxc_description: |
+#   Host is a test container. 
+#   Configured with onboot: no.
 pve_lxc_unprivileged: true
 pve_lxc_cores: 1
 pve_lxc_cpu_limit: 1

--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ Role Variables
 
 The `defaults` variables define the container parameters. To be specified by host under `host_vars/host_fqdn/vars` and eventually encrypted in `host_vars/host_fqdn/vault`.
 
-New interface in v3.0.0, with all role variables defined in the `pve_lxc_*` namespace. Update your host variables in your ansible code!
-
-To give time to update your whole inventory, the role preserves backward compatibility with [previous interface](https://github.com/UdelaRInterior/ansible-role-proxmox-create-lxc/blob/v2.2.0/README.md#role-variables) up to v4.X.Y release. 
+New interface introduced in v3.0.0 is maintained, with role's variables defined in the `pve_*` namespace when they are shared between several Proxmox roles, and in the `pve_lxc_*` namespace when they are specific to th present one. The role is no longer backward's compatible with [v2.X.Y previous interface](https://github.com/UdelaRInterior/ansible-role-proxmox-create-lxc/blob/v2.2.0/README.md#role-variables) and the role gives no longer a default value to `pve_lxc_root_password` in order to avoid unsecure container creation.
 
 ```yaml
 pve_hostname: "{{ inventory_hostname.split('.')[0] }}"
@@ -70,44 +68,44 @@ pve_lxc_swap: 512
 pve_lxc_disk: 32
 pve_lxc_storage: local-lvm
 pve_lxc_nameserver: 192.168.8.8 192.168.8.4
-pve_lxc_root_password: 123testing1234
+# pve_lxc_root_password:  # no default value, put yours in a vault. 
 pve_lxc_onboot: no
 
 pve_lxc_net_interfaces:
-  - id: net0
-    name: eth0
-    hwaddr: F6:A2:69:61:94:8D
-    ip4: 192.168.33.10        # ip4: dhcp (to use DHCP)
-    netmask4: 24
-    gw4: 192.168.33.1
-    ip6: 200:db8::10          # ip6: dhcp  (to use DHCP)  ### ip6: auto (to use SLAAC)
-    netmask6: 64
-    gw6: 200:db8::1
-    bridge: vmbr0
-    firewall: false  # Setting netif_firewall in TRUE, enable the use of firewall on the network interface
-    rate_limit: 5    # In MB/s
-    vlan_tag: 200
-  - id: net1
-    name: eth1
-    hwaddr: C6:A5:19:B1:92:7D
-    ip6: 200:db8::10          # ip6: dhcp  (to use DHCP)  ### ip6: auto (to use SLAAC)
-    netmask6: 64
-    bridge: vmbr1
+- id: net0
+  name: eth0
+  hwaddr: F6:A2:69:61:94:8D
+  ip4: 192.168.33.10        # ip4: dhcp (to use DHCP)
+  netmask4: 24
+  gw4: 192.168.33.1
+  ip6: 200:db8::10          # ip6: dhcp  (to use DHCP)  ### ip6: auto (to use SLAAC)
+  netmask6: 64
+  gw6: 200:db8::1
+  bridge: vmbr0
+  firewall: false  # Setting netif_firewall in TRUE, enable the use of firewall on the network interface
+  rate_limit: 5    # In MB/s
+  vlan_tag: 200
+- id: net1
+  name: eth1
+  hwaddr: C6:A5:19:B1:92:7D
+  ip6: 200:db8::10          # ip6: dhcp  (to use DHCP)  ### ip6: auto (to use SLAAC)
+  netmask6: 64
+  bridge: vmbr1
 
-pve_lxc_mounts:
-  - id: mp0
-    storage: local-lvm
-    size: 16
-    mount_point: "/mnt/data"
-    acl: false                     # Optional.
-    quota: false                   # Optional.
-    backup: false                  # Optional.
-    skip_replication: false        # Optional.
-    read_only: false               # Optional.
-  - id: mp1
-    storage: local-lvm
-    size: 8
-    mount_point: "/mnt/logs"
+pve_lxc_mounts: []
+# - id: mp0
+#   storage: local-lvm
+#   size: 16
+#   mount_point: "/mnt/data"
+#   acl: false                     # Optional.
+#   quota: false                   # Optional.
+#   backup: false                  # Optional.
+#   skip_replication: false        # Optional.
+#   read_only: false               # Optional.
+# - id: mp1
+#   storage: local-lvm
+#   size: 8
+#   mount_point: "/mnt/logs"
 
 # You can change the timeout for the operations of the module according to the performance of your remote host
 # pve_lxc_create_timeout: 30
@@ -126,7 +124,7 @@ Dependencies
 
 We need Ansible version > 2.5 (?) to have the appropriate API of Proxmox modules.
 
-Proxmox VE 5 installed in a the Proxmox node.
+Proxmox VE 5 or higher installed in a the Proxmox node or a cluster of several nodes.
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,7 @@ pve_lxc_node_deploy_password: "{{ node_deploy_password if node_deploy_password i
 # url_ostemplate: http://download.proxmox.com/images/system/debian-10.0-standard_10.0-1_amd64.tar.gz
 pve_lxc_url_ostemplate: "{{ url_ostemplate if url_ostemplate is defined else 'http://download.proxmox.com/images/system/debian-10.0-standard_10.0-1_amd64.tar.gz' }}"
 # pve_lxc_unprivileged: true    # Optional.
+## to be enabled for ansible 2.10
 # pve_lxc_description: |
 #   Host is a test container. 
 #   Configured with onboot: no.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,88 +6,87 @@ pve_hostname: "{{ inventory_hostname.split('.')[0] }}"
 # By default, we suppose that `inventory_hostname` is the FQDN or the hostname of the host to create, so we set the variable to the hostname. 
 # You can arbitrarly define this hostname
 
-# node: my_node
-pve_node: "{{ node if node is defined else 'my_node' }}"
-# api_host: my_node.my_cluster.org
-pve_api_host: "{{ api_host if api_host is defined else 'my_node.my_cluster.org' }}"
-# api_user: deploy@pam
-pve_api_user: "{{ api_user if api_user is defined else 'deploy@pam' }}"
-## Better put this in a vault
-# api_password: D3pl0y_pwd
-pve_api_password: "{{ node_deploy_password if node_deploy_password is defined else 'D3pl0y_pwd' }}" 
-# url_ostemplate: http://download.proxmox.com/images/system/debian-10.0-standard_10.0-1_amd64.tar.gz
-pve_lxc_url_ostemplate: "{{ url_ostemplate if url_ostemplate is defined else 'http://download.proxmox.com/images/system/debian-10.0-standard_10.0-1_amd64.tar.gz' }}"
+# proxmox node where we create or manage an LXC container
+pve_node: my_node
+# api_host: Proxmox API DNS or IP where we manage the Proxmox cluster or node 
+pve_api_host: my_node.my_cluster.org
+# api_user: User to connect to the Proxmox cluster API
+pve_api_user: deploy@pam
+# Password for the previous API user
+## Better put this in a vault, this dummy example can only cause an error.
+pve_api_password: D3pl0y_pwd
+# Proxmos LXC template we use to create the container
+pve_lxc_url_ostemplate: 'http://download.proxmox.com/images/system/debian-10.0-standard_10.0-1_amd64.tar.gz'
 # pve_lxc_unprivileged: true    # Optional.
 ## to be enabled for ansible 2.10
 # pve_lxc_description: |
 #   Host is a test container. 
 #   Configured with onboot: no.
-# cores: 1
-pve_lxc_cores: "{{ cores if cores is defined else '1' }}"
+# cores: 1  # Optional
+pve_lxc_cores: '1'
 # pve_lxc_cpu_limit: 1          # Optional.
 # pve_lxc_cpu_units: 1000       # Optional.
-# memory: 512
-pve_lxc_memory: "{{ memory if memory is defined else '512' }}"
+# Memory we configure in proxmox for the LXC container 
+pve_lxc_memory: 512
 # pve_lxc_swap: 512             # Optional.
-# disk: 32
-pve_lxc_disk: "{{ disk if disk is defined else '32' }}"
-# storage: local-lvm
-pve_lxc_storage: "{{ storage if storage is defined else 'local-lvm' }}"
-# nameserver: 192.168.8.8 192.168.8.4
-pve_lxc_nameserver: "{{ nameserver if nameserver is defined else '192.168.8.8 192.168.8.4' }}"
+# Size (in Gb) of the main disk we configure for the LXC
+pve_lxc_disk: 32
+# storage: Proxmox storage where we configure the container disk
+pve_lxc_storage: local-lvm
+# nameserver: NS resolvers that will use the container
+pve_lxc_nameserver: 192.168.8.8 192.168.8.4
 
-## Better put this in a vault
-# root_password: 123testing1234
-pve_lxc_root_password: "{{ root_password if root_password is defined else '123testing1234'}}"
+# root's password of the container
+## Better put this in a vault, the role no longer gives a default value, to avoid unsecure containter creation
+# pve_lxc_root_password: 123testing1234
 
 ## Start the container when node boot. It is recommended setting in 'yes' when container is in production
 # onboot: no
 pve_lxc_onboot: no
 
 # net_interfaces:
-pve_lxc_net_interfaces: "{{ net_interfaces if net_interfaces is defined else pve_lxc_net_interfaces_default }}"
-pve_lxc_net_interfaces_default:
-  - id: net0
-    name: eth0
-    hwaddr: F6:A2:69:61:94:8D   # Optional. If not indicated, Proxmox will assign one automatically.
-    ip4: 192.168.33.10          # Optional. Available options: valid IPv4 address (to use static) - dhcp (to use DHCP)
-    netmask4: 24                # Optional if IPv4 not indicated.
-    gw4: 192.168.33.1           # Optional.
-    ip6: 200:db8::10            # Optional. Available options: valid IPv6 address (to use static) - dhcp (to use DHCP) - auto (to use SLAAC)
-    netmask6: 64                # Optional if IPv6 not indicated.
-    gw6: 200:db8::1             # Optional.
-    bridge: vmbr0
-    firewall: false             # Optional. # Setting netif_firewall in TRUE, enable the use of firewall on the network interface
-    rate_limit: 5               # Optional. (In MB/s)
-    vlan_tag: 200               # Optional.
-  - id: net1
-    name: eth1
-    ip6: 200:db8::10
-    netmask6: 64
-    bridge: vmbr1
+pve_lxc_net_interfaces: 
+- id: net0
+  name: eth0
+  hwaddr: F6:A2:69:61:94:8D   # Optional. If not indicated, Proxmox will assign one automatically.
+  ip4: 192.168.33.10          # Optional. Available options: valid IPv4 address (to use static) - dhcp (to use DHCP)
+  netmask4: 24                # Optional if IPv4 not indicated.
+  gw4: 192.168.33.1           # Optional.
+  ip6: 200:db8::10            # Optional. Available options: valid IPv6 address (to use static) - dhcp (to use DHCP) - auto (to use SLAAC)
+  netmask6: 64                # Optional if IPv6 not indicated.
+  gw6: 200:db8::1             # Optional.
+  bridge: vmbr0
+  firewall: false             # Optional. # Setting netif_firewall in TRUE, enable the use of firewall on the network interface
+  rate_limit: 5               # Optional. (In MB/s)
+  vlan_tag: 200               # Optional.
+- id: net1
+  name: eth1
+  ip6: 200:db8::10
+  netmask6: 64
+  bridge: vmbr1
 
 # mounts: []  # No aditional mount points by default
-pve_lxc_mounts: "{{ mounts if mounts is defined else '[]' }}"  # No aditional mount points by default
-#   - id: mp0
-#     storage: local-lvm
-#     size: 16
-#     mount_point: "/mnt/data"
-#     acl: false                     # Optional.
-#     quota: false                   # Optional.
-#     backup: false                  # Optional.
-#     skip_replication: false        # Optional.
-#     read_only: false               # Optional.
-#   - id: mp1
-#     storage: local-lvm
-#     size: 8
-#     mount_point: "/mnt/logs"
+pve_lxc_mounts: []  # No aditional mount points by default
+# - id: mp0
+#   storage: local-lvm
+#   size: 16
+#   mount_point: "/mnt/data"
+#   acl: false                     # Optional.
+#   quota: false                   # Optional.
+#   backup: false                  # Optional.
+#   skip_replication: false        # Optional.
+#   read_only: false               # Optional.
+# - id: mp1
+#   storage: local-lvm
+#   size: 8
+#   mount_point: "/mnt/logs"
 
 # You can change the timeout for the operations of the module according to the performance of your remote host
 # pve_lxc_create_timeout: 30 
 
 # Additional "manual" settings to add to the file /etc/pve/nodes/{{ node }}/lxc/{{ VMID }}.conf
 # pve_additional_conf: []
-pve_lxc_additional_conf: "{{ pve_additional_conf if pve_additional_conf is defined else '[]' }}"
+pve_lxc_additional_conf: []
         # Kernel modules available within the LXC
   # - 'mp0: /lib/modules/4.15.18-9-pve,mp=/lib/modules/4.15.18-9-pve,ro=1'
         # tun device for OpenVPN server inside LXC

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,19 +2,19 @@
 # defaults file for ansible-role-proxmox-create-lxc/
 # vars needed to define the parameters for the wraped proxmox api
 
-pve_lxc_hostname: "{{ inventory_hostname.split('.')[0] }}"
+pve_hostname: "{{ inventory_hostname.split('.')[0] }}"
 # By default, we suppose that `inventory_hostname` is the FQDN or the hostname of the host to create, so we set the variable to the hostname. 
 # You can arbitrarly define this hostname
 
 # node: my_node
-pve_lxc_node: "{{ node if node is defined else 'my_node' }}"
+pve_node: "{{ node if node is defined else 'my_node' }}"
 # api_host: my_node.my_cluster.org
-pve_lxc_api_host: "{{ api_host if api_host is defined else 'my_node.my_cluster.org' }}"
+pve_api_host: "{{ api_host if api_host is defined else 'my_node.my_cluster.org' }}"
 # api_user: deploy@pam
-pve_lxc_api_user: "{{ api_user if api_user is defined else 'deploy@pam' }}"
+pve_api_user: "{{ api_user if api_user is defined else 'deploy@pam' }}"
 ## Better put this in a vault
-# node_deploy_password: D3pl0y_pwd
-pve_lxc_node_deploy_password: "{{ node_deploy_password if node_deploy_password is defined else 'D3pl0y_pwd' }}" 
+# api_password: D3pl0y_pwd
+pve_api_password: "{{ node_deploy_password if node_deploy_password is defined else 'D3pl0y_pwd' }}" 
 # url_ostemplate: http://download.proxmox.com/images/system/debian-10.0-standard_10.0-1_amd64.tar.gz
 pve_lxc_url_ostemplate: "{{ url_ostemplate if url_ostemplate is defined else 'http://download.proxmox.com/images/system/debian-10.0-standard_10.0-1_amd64.tar.gz' }}"
 # pve_lxc_unprivileged: true    # Optional.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,9 @@ pve_lxc_node_deploy_password: "{{ node_deploy_password if node_deploy_password i
 # url_ostemplate: http://download.proxmox.com/images/system/debian-10.0-standard_10.0-1_amd64.tar.gz
 pve_lxc_url_ostemplate: "{{ url_ostemplate if url_ostemplate is defined else 'http://download.proxmox.com/images/system/debian-10.0-standard_10.0-1_amd64.tar.gz' }}"
 # pve_lxc_unprivileged: true    # Optional.
+# pve_lxc_description: |
+#   Host is a test container. 
+#   Configured with onboot: no.
 # cores: 1
 pve_lxc_cores: "{{ cores if cores is defined else '1' }}"
 # pve_lxc_cpu_limit: 1          # Optional.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,28 +2,47 @@
 # defaults file for ansible-role-proxmox-create-lxc/
 # vars needed to define the parameters for the wraped proxmox api
 
-node: my_node
-api_host: my_node.my_cluster.org
-api_user: deploy@pam
-node_deploy_password: D3pl0y_pwd
-url_ostemplate: http://download.proxmox.com/images/system/debian-10.0-standard_10.0-1_amd64.tar.gz
-# unprivileged: true    # Optional.
-cores: 1
-# cpu_limit: 1          # Optional.
-# cpu_units: 1000       # Optional.
-memory: 512
-# swap: 512             # Optional.
-disk: 32
-storage: local-lvm
-nameserver: 192.168.8.8 192.168.8.4
+pve_lxc_hostname: "{{ inventory_hostname.split('.')[0] }}"
+# By default, we suppose that `inventory_hostname` is the FQDN or the hostname of the host to create, so we set the variable to the hostname. 
+# You can arbitrarly define this hostname
+
+# node: my_node
+pve_lxc_node: "{{ node if node is defined else 'my_node' }}"
+# api_host: my_node.my_cluster.org
+pve_lxc_api_host: "{{ api_host if api_host is defined else 'my_node.my_cluster.org' }}"
+# api_user: deploy@pam
+pve_lxc_api_user: "{{ api_user if api_user is defined else 'deploy@pam' }}"
+## Better put this in a vault
+# node_deploy_password: D3pl0y_pwd
+pve_lxc_node_deploy_password: "{{ node_deploy_password if node_deploy_password is defined else 'D3pl0y_pwd' }}" 
+# url_ostemplate: http://download.proxmox.com/images/system/debian-10.0-standard_10.0-1_amd64.tar.gz
+pve_lxc_url_ostemplate: "{{ url_ostemplate if url_ostemplate is defined else 'http://download.proxmox.com/images/system/debian-10.0-standard_10.0-1_amd64.tar.gz' }}"
+# pve_lxc_unprivileged: true    # Optional.
+# cores: 1
+pve_lxc_cores: "{{ cores if cores is defined else '1' }}"
+# pve_lxc_cpu_limit: 1          # Optional.
+# pve_lxc_cpu_units: 1000       # Optional.
+# memory: 512
+pve_lxc_memory: "{{ memory if memory is defined else '512' }}"
+# pve_lxc_swap: 512             # Optional.
+# disk: 32
+pve_lxc_disk: "{{ disk if disk is defined else '32' }}"
+# storage: local-lvm
+pve_lxc_storage: "{{ storage if storage is defined else 'local-lvm' }}"
+# nameserver: 192.168.8.8 192.168.8.4
+pve_lxc_nameserver: "{{ nameserver if nameserver is defined else '192.168.8.8 192.168.8.4' }}"
 
 ## Better put this in a vault
-root_password: 123testing1234
+# root_password: 123testing1234
+pve_lxc_root_password: "{{ root_password if root_password is defined else '123testing1234'}}"
 
 ## Start the container when node boot. It is recommended setting in 'yes' when container is in production
-onboot: no
+# onboot: no
+pve_lxc_onboot: no
 
-net_interfaces:
+# net_interfaces:
+pve_lxc_net_interfaces: "{{ net_interfaces if net_interfaces is defined else pve_lxc_net_interfaces_default }}"
+pve_lxc_net_interfaces_default:
   - id: net0
     name: eth0
     hwaddr: F6:A2:69:61:94:8D   # Optional. If not indicated, Proxmox will assign one automatically.
@@ -43,7 +62,8 @@ net_interfaces:
     netmask6: 64
     bridge: vmbr1
 
-mounts: []  # No aditional mount points by default
+# mounts: []  # No aditional mount points by default
+pve_lxc_mounts: "{{ mounts if mounts is defined else '[]' }}"  # No aditional mount points by default
 #   - id: mp0
 #     storage: local-lvm
 #     size: 16
@@ -59,12 +79,15 @@ mounts: []  # No aditional mount points by default
 #     mount_point: "/mnt/logs"
 
 # You can change the timeout for the operations of the module according to the performance of your remote host
-# proxmox_create_lxc_timeout: 30 
+# pve_lxc_create_timeout: 30 
 
 # Additional "manual" settings to add to the file /etc/pve/nodes/{{ node }}/lxc/{{ VMID }}.conf
-pve_additional_conf: []
+# pve_additional_conf: []
+pve_lxc_additional_conf: "{{ pve_additional_conf if pve_additional_conf is defined else '[]' }}"
         # Kernel modules available within the LXC
   # - 'mp0: /lib/modules/4.15.18-9-pve,mp=/lib/modules/4.15.18-9-pve,ro=1'
         # tun device for OpenVPN server inside LXC
   # - 'lxc.cgroup.devices.allow = c 10:200 rwm'
   # - 'lxc.hook.autodev = sh -c "modprobe tun; cd ${LXC_ROOTFS_MOUNT}/dev; mkdir net; mknod net/tun c 10 200; chmod 0666 net/tun"'
+
+...

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,9 +3,11 @@
 
 # Repintiendo ping cada 3s hasta que el el contenedor arranque
 # Repeating ping every 3 seconds until the container starts
-- name: wait for connection
+- name: pve_lxc wait for connection
   wait_for_connection:
     delay: 3
     sleep: 3
     timeout: 30
   remote_user: root
+
+...

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,3 +1,4 @@
+---
 galaxy_info:
   role_name: proxmox_create_lxc
   author: 'Daniel Viñar (@ulvida) and Santiago Martínez (@santiagomr)'
@@ -12,6 +13,7 @@ galaxy_info:
     - name: Debian
       versions:
         - stretch
+        - buster
 
   galaxy_tags:
     - system
@@ -23,3 +25,5 @@ galaxy_info:
     - sysadmin
 
 dependencies: []
+
+...

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
 
   license: GPLv3
 
-  min_ansible_version: 2.5
+  min_ansible_version: 2.9
 
   platforms:
     - name: Debian

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,32 +2,27 @@
 # proxmox_create_lxc: creation of a complete LXC container in Proxmox cluster
 # tasks file for ansible-role-proxmox-create-lxc/
 
-# Extraer el hostname del inventory_hostname (debe ser el fqdn)
-- name: Extract hostname from inventory_hostname (must be fqdn)
-  set_fact:
-    proxmox_hostname: "{{ inventory_hostname.split('.')[0] }}"
-
 # Verificar si python-pip está instalado en el nodo proxmox
 - name: Verify that python-pip is installed in the Proxmox node
   apt:
     name: python-pip
     state: present
-  delegate_to: "{{ api_host }}"
+  delegate_to: "{{ pve_lxc_api_host }}"
 
 #  Verificar si el módulo proxmoxer de python está instalado
 - name: Verify if proxmoxer pip module is installed
   pip:
     name: proxmoxer
     state: present
-  delegate_to: "{{ api_host }}"
+  delegate_to: "{{ pve_lxc_api_host }}"
 
 # Descargar la plantilla del contenedor
 - name: Download the container template
   get_url:
-    url: "{{ url_ostemplate }}"
+    url: "{{ pve_lxc_url_ostemplate }}"
     dest: /var/lib/vz/template/cache/
-  delegate_to: "{{ api_host }}"
-  register: descarga_ostemplate
+  delegate_to: "{{ pve_lxc_api_host }}"
+  register: pve_lxc_download_ostemplate
   tags:
     - descarga
     - download
@@ -35,14 +30,14 @@
 # Agregar template lxc del container al nodo
 - name: Add LXC container template to node
   proxmox_template:
-      node: "{{ node }}"
-      api_user: "{{ api_user }}"
-      api_host: "{{ api_host }}"
-      api_password: "{{ node_deploy_password }}"
-      src: "{{ descarga_ostemplate.dest }}"
+      node: "{{ pve_lxc_node }}"
+      api_user: "{{ pve_lxc_api_user }}"
+      api_host: "{{ pve_lxc_api_host }}"
+      api_password: "{{ pve_lxc_node_deploy_password }}"
+      src: "{{ pve_lxc_download_ostemplate.dest }}"
       content_type: vztmpl
       state: present
-  delegate_to: "{{ api_host }}"
+  delegate_to: "{{ pve_lxc_api_host }}"
   tags:
       - descarga
       - download
@@ -50,46 +45,46 @@
 # Creando el container
 - name: Create the container
   proxmox:
-    node: "{{ node }}"
-    api_user: "{{ api_user }}"
-    api_host: "{{ api_host }}"
-    api_password: "{{ node_deploy_password }}"
-    hostname: "{{ proxmox_hostname }}"
-    ostemplate: "local:vztmpl/{{ url_ostemplate | urlsplit('path') | basename }}"
-    password: "{{ root_password }}"
+    node: "{{ pve_lxc_node }}"
+    api_user: "{{ pve_lxc_api_user }}"
+    api_host: "{{ pve_lxc_api_host }}"
+    api_password: "{{ pve_lxc_node_deploy_password }}"
+    hostname: "{{ pve_lxc_hostname }}"
+    ostemplate: "local:vztmpl/{{ pve_lxc_url_ostemplate | urlsplit('path') | basename }}"
+    password: "{{ pve_lxc_root_password }}"
     pubkey: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
-    cores: "{{ cores }}"
-    cpus: "{{ cpu_limit | default(omit) }}"
-    cpuunits: "{{ cpu_units | default(omit) }}"
-    memory: "{{ memory }}"
-    swap: "{{ swap | default(omit) }}"
-    storage: "{{ storage }}"
-    disk: "{{ disk }}"
+    cores: "{{ pve_lxc_cores }}"
+    cpus: "{{ pve_lxc_cpu_limit | default(omit) }}"
+    cpuunits: "{{ pve_lxc_cpu_units | default(omit) }}"
+    memory: "{{ pve_lxc_memory }}"
+    swap: "{{ pve_lxc_swap | default(omit) }}"
+    storage: "{{ pve_lxc_storage }}"
+    disk: "{{ pve_lxc_disk }}"
     mounts: >-
-      {   {%- for item in mounts -%}
+      {   {%- for item in pve_lxc_mounts -%}
             "{{ item.id }}":"{{ item.storage|default('local-lvm') }}:{{ item.size|default(32) }},mp={{ item.mount_point|default('/mnt/mp0') }},{% if item.acl is defined %}{% if (item.acl) %}acl=1{% else %}acl=0{% endif %},{% endif %}{% if item.quota is defined and item.quota %}quota=1,{% endif %}{% if item.read_only is defined and item.read_only %}ro=1,{% endif %}{% if item.backup is defined and item.backup %}backup=1,{% endif %}{% if item.skip_replication is defined and item.skip_replication %}replicate=0{% endif %}",
           {%- endfor -%}  }
     netif: >-
-      {   {%- for item in net_interfaces -%}
+      {   {%- for item in pve_lxc_net_interfaces -%}
             "{{ item.id }}":"name={{ item.name }},bridge={{ item.bridge }},{% if (item.hwaddr is defined) %}hwaddr={{ item.hwaddr }},{% endif %}{% if (item.ip4 is defined) %}ip={{ item.ip4 }}/{{ item.netmask4 }},{% endif %}{% if (item.gw4 is defined) %}gw={{ item.gw4 }},{% endif %}{% if (item.ip6 is defined) %}ip6={{ item.ip6 }}/{{ item.netmask6 }},{% endif %}{% if (item.gw6 is defined) %}gw6={{ item.gw6 }},{% endif %}{% if (item.firewall is defined and item.firewall) %}firewall=1,{% endif %}{% if (item.rate_limit is defined) %}rate={{ item.rate_limit }},{% endif %}{% if (item.vlan_tag is defined) %}tag={{ item.vlan_tag }}{% endif %}",
           {%- endfor -%}  }
-    nameserver: "{{ nameserver }}"
-    onboot: "{{ onboot | default(omit) }}"
-    unprivileged: "{{ unprivileged | default(omit) }}"
-    timeout: "{{ proxmox_create_lxc_timeout | default(omit) }}"
-  delegate_to: "{{ api_host }}"
-  register: container
+    nameserver: "{{ pve_lxc_nameserver }}"
+    onboot: "{{ pve_lxc_onboot | default(omit) }}"
+    unprivileged: "{{ pve_lxc_unprivileged | default(omit) }}"
+    timeout: "{{ pve_lxc_create_timeout | default(omit) }}"
+  delegate_to: "{{ pve_lxc_api_host }}"
+  register: pve_lxc_create_container
 
 # Extraer el número de VM
 - name: Extract the ID of the VM from container var
   shell: |
     set -o pipefail
-    pct list | grep -w "{{ proxmox_hostname }}" | cut -f 1 -d ' '
+    pct list | grep -w "{{ pve_lxc_hostname }}" | cut -f 1 -d ' '
   args:
     executable: /bin/bash
-  delegate_to: "{{ api_host }}"
-  register: VMID
-  when: container is succeeded
+  delegate_to: "{{ pve_lxc_api_host }}"
+  register: pve_lxc_VMID
+  when: pve_lxc_create_container is succeeded
   changed_when: false
   tags:
     - deploy
@@ -102,22 +97,24 @@
   # replace the configuration files located in /etc/pve/...
 # See https://github.com/UdelaRInterior/ansible-role-proxmox-create-lxc/issues/8
 - name: Additional configurations
-  shell: echo '{{ item }}' >> /etc/pve/nodes/{{ node }}/lxc/{{ VMID.stdout }}.conf
-  with_items: "{{ pve_additional_conf }}"
-  when: (pve_additional_conf is defined) and (container.changed | bool)
+  shell: echo '{{ item }}' >> /etc/pve/nodes/{{ pve_lxc_node }}/lxc/{{ pve_lxc_VMID.stdout }}.conf
+  with_items: "{{ pve_lxc_additional_conf }}"
+  when: (pve_lxc_additional_conf is defined) and (pve_lxc_create_container | bool)
   delegate_to: "{{ api_host }}"
 
 # Arrancar el contenedor
 - name: Turn on the container
   proxmox:
-    node: "{{ node }}"
-    api_user: "{{ api_user }}"
-    api_host: "{{ api_host }}"
-    api_password: "{{ node_deploy_password }}"
-    vmid: "{{ VMID.stdout }}"
+    node: "{{ pve_lxc_node }}"
+    api_user: "{{ pve_lxc_api_user }}"
+    api_host: "{{ pve_lxc_api_host }}"
+    api_password: "{{ pve_lxc_node_deploy_password }}"
+    vmid: "{{ pve_lxc_VMID.stdout }}"
     state: started
-  delegate_to: "{{ api_host }}"
-  notify: wait for connection
-  when: (container is not defined) or (container is succeeded)
+  delegate_to: "{{ pve_lxc_api_host }}"
+  notify: pve_lxc wait for connection
+  when: (pve_lxc_create_container is not defined) or (pve_lxc_create_container is succeeded)
   tags:
     - deploy
+
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -101,8 +101,8 @@
 - name: Additional configurations
   shell: echo '{{ item }}' >> /etc/pve/nodes/{{ pve_node }}/lxc/{{ pve_lxc_VMID.stdout }}.conf
   with_items: "{{ pve_lxc_additional_conf }}"
-  when: (pve_lxc_additional_conf is defined) and (pve_lxc_create_container | bool)
-  delegate_to: "{{ api_host }}"
+  when: (pve_lxc_additional_conf is defined) and (pve_lxc_create_container is changed)
+  delegate_to: "{{ pve_api_host }}"
 
 # Arrancar el contenedor
 - name: Turn on the container

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,7 +53,8 @@
     ostemplate: "local:vztmpl/{{ pve_lxc_url_ostemplate | urlsplit('path') | basename }}"
     password: "{{ pve_lxc_root_password }}"
     pubkey: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
-    description: "{{ pve_lxc_description | default(omit) }}"
+    # to be abled for ansible 2.10 compatible version
+    # description: "{{ pve_lxc_description | default(omit) }}"
     cores: "{{ pve_lxc_cores }}"
     cpus: "{{ pve_lxc_cpu_limit | default(omit) }}"
     cpuunits: "{{ pve_lxc_cpu_units | default(omit) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,6 +53,7 @@
     ostemplate: "local:vztmpl/{{ pve_lxc_url_ostemplate | urlsplit('path') | basename }}"
     password: "{{ pve_lxc_root_password }}"
     pubkey: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+    description: "{{ pve_lxc_description | default(omit) }}"
     cores: "{{ pve_lxc_cores }}"
     cpus: "{{ pve_lxc_cpu_limit | default(omit) }}"
     cpuunits: "{{ pve_lxc_cpu_units | default(omit) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,21 +7,21 @@
   apt:
     name: python-pip
     state: present
-  delegate_to: "{{ pve_lxc_api_host }}"
+  delegate_to: "{{ pve_api_host }}"
 
 #  Verificar si el módulo proxmoxer de python está instalado
 - name: Verify if proxmoxer pip module is installed
   pip:
     name: proxmoxer
     state: present
-  delegate_to: "{{ pve_lxc_api_host }}"
+  delegate_to: "{{ pve_api_host }}"
 
 # Descargar la plantilla del contenedor
 - name: Download the container template
   get_url:
     url: "{{ pve_lxc_url_ostemplate }}"
     dest: /var/lib/vz/template/cache/
-  delegate_to: "{{ pve_lxc_api_host }}"
+  delegate_to: "{{ pve_api_host }}"
   register: pve_lxc_download_ostemplate
   tags:
     - descarga
@@ -30,14 +30,14 @@
 # Agregar template lxc del container al nodo
 - name: Add LXC container template to node
   proxmox_template:
-      node: "{{ pve_lxc_node }}"
-      api_user: "{{ pve_lxc_api_user }}"
-      api_host: "{{ pve_lxc_api_host }}"
-      api_password: "{{ pve_lxc_node_deploy_password }}"
+      node: "{{ pve_node }}"
+      api_user: "{{ pve_api_user }}"
+      api_host: "{{ pve_api_host }}"
+      api_password: "{{ pve_api_password }}"
       src: "{{ pve_lxc_download_ostemplate.dest }}"
       content_type: vztmpl
       state: present
-  delegate_to: "{{ pve_lxc_api_host }}"
+  delegate_to: "{{ pve_api_host }}"
   tags:
       - descarga
       - download
@@ -45,11 +45,11 @@
 # Creando el container
 - name: Create the container
   proxmox:
-    node: "{{ pve_lxc_node }}"
-    api_user: "{{ pve_lxc_api_user }}"
-    api_host: "{{ pve_lxc_api_host }}"
-    api_password: "{{ pve_lxc_node_deploy_password }}"
-    hostname: "{{ pve_lxc_hostname }}"
+    node: "{{ pve_node }}"
+    api_user: "{{ pve_api_user }}"
+    api_host: "{{ pve_api_host }}"
+    api_password: "{{ pve_api_password }}"
+    hostname: "{{ pve_hostname }}"
     ostemplate: "local:vztmpl/{{ pve_lxc_url_ostemplate | urlsplit('path') | basename }}"
     password: "{{ pve_lxc_root_password }}"
     pubkey: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
@@ -74,17 +74,17 @@
     onboot: "{{ pve_lxc_onboot | default(omit) }}"
     unprivileged: "{{ pve_lxc_unprivileged | default(omit) }}"
     timeout: "{{ pve_lxc_create_timeout | default(omit) }}"
-  delegate_to: "{{ pve_lxc_api_host }}"
+  delegate_to: "{{ pve_api_host }}"
   register: pve_lxc_create_container
 
 # Extraer el número de VM
 - name: Extract the ID of the VM from container var
   shell: |
     set -o pipefail
-    pct list | grep -w "{{ pve_lxc_hostname }}" | cut -f 1 -d ' '
+    pct list | grep -w "{{ pve_hostname }}" | cut -f 1 -d ' '
   args:
     executable: /bin/bash
-  delegate_to: "{{ pve_lxc_api_host }}"
+  delegate_to: "{{ pve_api_host }}"
   register: pve_lxc_VMID
   when: pve_lxc_create_container is succeeded
   changed_when: false
@@ -99,7 +99,7 @@
   # replace the configuration files located in /etc/pve/...
 # See https://github.com/UdelaRInterior/ansible-role-proxmox-create-lxc/issues/8
 - name: Additional configurations
-  shell: echo '{{ item }}' >> /etc/pve/nodes/{{ pve_lxc_node }}/lxc/{{ pve_lxc_VMID.stdout }}.conf
+  shell: echo '{{ item }}' >> /etc/pve/nodes/{{ pve_node }}/lxc/{{ pve_lxc_VMID.stdout }}.conf
   with_items: "{{ pve_lxc_additional_conf }}"
   when: (pve_lxc_additional_conf is defined) and (pve_lxc_create_container | bool)
   delegate_to: "{{ api_host }}"
@@ -107,13 +107,13 @@
 # Arrancar el contenedor
 - name: Turn on the container
   proxmox:
-    node: "{{ pve_lxc_node }}"
-    api_user: "{{ pve_lxc_api_user }}"
-    api_host: "{{ pve_lxc_api_host }}"
-    api_password: "{{ pve_lxc_node_deploy_password }}"
+    node: "{{ pve_node }}"
+    api_user: "{{ pve_api_user }}"
+    api_host: "{{ pve_api_host }}"
+    api_password: "{{ pve_api_password }}"
     vmid: "{{ pve_lxc_VMID.stdout }}"
     state: started
-  delegate_to: "{{ pve_lxc_api_host }}"
+  delegate_to: "{{ pve_api_host }}"
   notify: pve_lxc wait for connection
   when: (pve_lxc_create_container is not defined) or (pve_lxc_create_container is succeeded)
   tags:


### PR DESCRIPTION
I define a new uniform namespace for their role's variables, all starting with pve_lxc_, preserving backwards compatibility with previous [roles interface](https://github.com/UdelaRInterior/ansible-role-proxmox-create-lxc/blob/v2.2.0/README.md#role-variables).

Now it's possible to define `pve_lxc_hostname` in the varialbles of an installed host, to define pve hostname. 