### PR TITLE
Coherence on the vars namespaces with companion KVM role and other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,15 @@ New interface introduced in v3.0.0 is maintained, with role's variables defined 
 ### Proxmox API connection and authentication section ###
 #########################################################
 
-# Various module options used to have default values. This cause problems when user expects different behavior from proxmox
-# by default or fill options which cause problems when they have been set. The default value is compatibility, which will
-# ensure that the default values are used when the values are not explicitly specified by the user.From community.general
-# 4.0.0 on, the default value will switch to no_defaults. To avoid deprecation warnings, please set proxmox_default_behavior
-# to an explicit value. This affects the disk, cores, cpus, memory, onboot, swap, cpuunits options.
-# See https://docs.ansible.com/ansible/latest/collections/community/general/proxmox_module.html#parameter-proxmox_default_behavior
-pve_lxc_proxmox_default_behavior: compatibility
+# Flag to determine the behavior of the variables default values
+  # Various module options used to have default values. This cause problems when user expects different behavior from proxmox
+  # by default or fill options which cause problems when they have been set. The default value is "compatibility", which will
+  # ensure that the default values are used when the values are not explicitly specified by the user.From community.general
+  # 4.0.0 on, the default value will switch to "no_defaults". To avoid deprecation warnings, please set proxmox_default_behavior
+  # to an explicit value. This affects the disk, cores, cpus, memory, onboot, swap, cpuunits options.
+  # See https://docs.ansible.com/ansible/latest/collections/community/general/proxmox_module.html#parameter-proxmox_default_behavior
+  # Choices: compatibility - no_defaults
+pve_default_behavior: compatibility
 
 # Proxmox node hostname where we create or manage an LXC container
 pve_node: mynode
@@ -72,6 +74,8 @@ pve_api_password: PaSsWd_f0r-AuToMaTi0nS    # Optional if token authentication i
 # pve_api_token_id: automations@pam!ansible                       # Optional if user-password based authentication is used
 # pve_api_token_secret: 0b029a23-1ca3-a93f-8d90-5a4c9d064199      # Optional if user-password based authentication is used
 
+# Validate the node's certificates when creating the container
+# pve_validate_certs: no                      # Optional.
 
 #####################################
 ### Container OS template section ###
@@ -88,7 +92,6 @@ pve_lxc_ostemplate_storage: local                                               
 pve_lxc_ostemplate_content_type: vztmpl                                               # Optional.
 pve_lxc_ostemplate_timeout: 60 # in seconds                                           # Optional.
 pve_lxc_ostemplate_force: no                                                          # Optional.
-pve_lxc_ostemplate_validate_certs: no                                                 # Optional.
 pve_lxc_ostemplate_state: present                                                     # Optional.
 
 
@@ -98,9 +101,6 @@ pve_lxc_ostemplate_state: present                                               
 
 # You can change the timeout for operations of the module according to the performance of your remote host
 pve_lxc_timeout: 30                             # Optional.
-
-# Validate the node's certificates when creating the container
-pve_lxc_validate_certs: no                      # Optional.
 
 # By default, we suppose that `inventory_hostname` is the FQDN or the hostname of the host to create, so we set the variable to the hostname.
 # You can arbitrarly define this hostname
@@ -131,7 +131,7 @@ pve_lxc_disk: 16                                  # Optional.
 pve_lxc_storage: local-lvm
 
 # Start the container when node boot. It is recommended setting in 'yes' when container is in production
-pve_lxc_onboot: no                                # Optional.
+pve_onboot: no                                    # Optional.
 
 # pve_lxc_ip_address: 192.168.33.10               # Optional.
 pve_lxc_nameserver: 1.1.1.1 1.0.0.1               # Optional.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,7 @@ pve_api_password: PaSsWd_f0r-AuToMaTi0nS    # Optional if token authentication i
 
 # Proxmox LXC template we use to create the container
 # The name of an appliance container template (pveam)
-pve_lxc_ostemplate_name: debian-10.0-standard_10.0-1_amd64.tar.gz
+# pve_lxc_ostemplate_name: debian-10.0-standard_10.0-1_amd64.tar.gz                   # Optional.
     # Optional. It is used only if a name of an appliance container template (pveam) was not defined in the variable pve_lxc_ostemplate_name
 # pve_lxc_ostemplate_url: http://download.proxmox.com/images/system/debian-10.0-standard_10.0-1_amd64.tar.gz
 
@@ -64,35 +64,35 @@ pve_hostname: "{{ inventory_hostname.split('.')[0] }}"
 
 # pve_lxc_vmid: 200                               # Optional.
 
-pve_lxc_description: |                            # Optional.
-  This host is a Debian Buster example container configured via Ansible with:
-  - 1 CPU cores
-  - 512MB of RAM
-  - 16GB of system disk
-  - unprivileged: yes
-  - onboot: no
+# pve_lxc_description: |                            # Optional.
+#   This host is a Debian Buster example container configured via Ansible with:
+#   - 1 CPU cores
+#   - 512MB of RAM
+#   - 16GB of system disk
+#   - unprivileged: yes
+#   - onboot: no
 
 pve_lxc_root_password: # no default value for security reasons, put yours in a vault.
-pve_lxc_root_authorized_pubkey: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}" # Ansible controller default public key
+# pve_lxc_root_authorized_pubkey: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}" # Ansible controller default public key # Optional.
 
-pve_lxc_cpu_cores: 1                              # Optional.
+# pve_lxc_cpu_cores: 1                            # Optional.
 # pve_lxc_cpu_limit: 1                            # Optional.
 # pve_lxc_cpu_units: 1000                         # Optional.
 
-pve_lxc_memory: 512                               # Optional.
+# pve_lxc_memory: 512                             # Optional.
 # pve_lxc_swap: 512                               # Optional.
 
 # Size (in GB) of the main disk we configure for the LXC
-pve_lxc_disk: 16                                  # Optional.
-pve_lxc_storage: local-lvm
+# pve_lxc_disk: 16                                # Optional.
+# pve_lxc_storage: local-lvm                      # Optional.
 
 # Start the container when node boot. It is recommended setting in 'yes' when container is in production
-pve_onboot: no                                    # Optional.
+# pve_onboot: no                                  # Optional.
 
 # pve_lxc_ip_address: 192.168.33.10               # Optional.
-pve_lxc_nameserver: 1.1.1.1 1.0.0.1               # Optional.
+# pve_lxc_nameserver: 1.1.1.1 1.0.0.1             # Optional.
 # pve_lxc_searchdomain: mycluster.org             # Optional.
-pve_lxc_unprivileged: yes                         # Optional.
+# pve_lxc_unprivileged: yes                       # Optional.
 # pve_lxc_force: no                               # Optional.
 # pve_lxc_features:                               # Optional.
 #   - nesting=1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,13 +6,15 @@
 ### Proxmox API connection and authentication section ###
 #########################################################
 
-# Various module options used to have default values. This cause problems when user expects different behavior from proxmox
-# by default or fill options which cause problems when they have been set. The default value is compatibility, which will
-# ensure that the default values are used when the values are not explicitly specified by the user.From community.general
-# 4.0.0 on, the default value will switch to no_defaults. To avoid deprecation warnings, please set proxmox_default_behavior
-# to an explicit value. This affects the disk, cores, cpus, memory, onboot, swap, cpuunits options.
-# See https://docs.ansible.com/ansible/latest/collections/community/general/proxmox_module.html#parameter-proxmox_default_behavior
-pve_lxc_proxmox_default_behavior: compatibility
+# Flag to determine the behavior of the variables default values
+  # Various module options used to have default values. This cause problems when user expects different behavior from proxmox
+  # by default or fill options which cause problems when they have been set. The default value is "compatibility", which will
+  # ensure that the default values are used when the values are not explicitly specified by the user.From community.general
+  # 4.0.0 on, the default value will switch to "no_defaults". To avoid deprecation warnings, please set proxmox_default_behavior
+  # to an explicit value. This affects the disk, cores, cpus, memory, onboot, swap, cpuunits options.
+  # See https://docs.ansible.com/ansible/latest/collections/community/general/proxmox_module.html#parameter-proxmox_default_behavior
+  # Choices: compatibility - no_defaults
+pve_default_behavior: compatibility
 
 # Proxmox node hostname where we create or manage an LXC container
 pve_node: mynode
@@ -28,6 +30,8 @@ pve_api_password: PaSsWd_f0r-AuToMaTi0nS    # Optional if token authentication i
 # pve_api_token_id: automations@pam!ansible                       # Optional if user-password based authentication is used
 # pve_api_token_secret: 0b029a23-1ca3-a93f-8d90-5a4c9d064199      # Optional if user-password based authentication is used
 
+# Validate the node's certificates when creating the container
+# pve_validate_certs: no                      # Optional.
 
 #####################################
 ### Container OS template section ###
@@ -44,7 +48,6 @@ pve_lxc_ostemplate_name: debian-10.0-standard_10.0-1_amd64.tar.gz
 # pve_lxc_ostemplate_content_type: vztmpl                                             # Optional.
 # pve_lxc_ostemplate_timeout: 60 # in seconds                                         # Optional.
 # pve_lxc_ostemplate_force: no                                                        # Optional.
-# pve_lxc_ostemplate_validate_certs: no                                               # Optional.
 # pve_lxc_ostemplate_state: present                                                   # Optional.
 
 
@@ -54,9 +57,6 @@ pve_lxc_ostemplate_name: debian-10.0-standard_10.0-1_amd64.tar.gz
 
 # You can change the timeout for operations of the module according to the performance of your remote host
 # pve_lxc_timeout: 30                             # Optional.
-
-# Validate the node's certificates when creating the container
-# pve_lxc_validate_certs: no                      # Optional.
 
 # By default, we suppose that `inventory_hostname` is the FQDN or the hostname of the host to create, so we set the variable to the hostname.
 # You can arbitrarly define this hostname
@@ -87,7 +87,7 @@ pve_lxc_disk: 16                                  # Optional.
 pve_lxc_storage: local-lvm
 
 # Start the container when node boot. It is recommended setting in 'yes' when container is in production
-pve_lxc_onboot: no                                # Optional.
+pve_onboot: no                                    # Optional.
 
 # pve_lxc_ip_address: 192.168.33.10               # Optional.
 pve_lxc_nameserver: 1.1.1.1 1.0.0.1               # Optional.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
     content_type: "{{ pve_lxc_ostemplate_content_type | default(omit) }}"
     timeout: "{{ pve_lxc_ostemplate_timeout | default(omit) }}"
     force: "{{ pve_lxc_ostemplate_force | default(omit) }}"
-    validate_certs: "{{ pve_lxc_ostemplate_validate_certs | default(omit) }}"
+    validate_certs: "{{ pve_validate_certs | default(omit) }}"
     state: "{{ pve_lxc_ostemplate_state  | default(omit) }}"
   delegate_to: "{{ pve_api_host }}"
   tags:
@@ -61,8 +61,8 @@
     api_password: "{{ pve_api_password | default(omit) }}"
     api_token_id: "{{ pve_api_token_id | default(omit) }}"
     api_token_secret: "{{ pve_api_token_secret | default(omit) }}"
-    proxmox_default_behavior: "{{ pve_lxc_proxmox_default_behavior | default('compatibility') }}"
-    validate_certs: "{{ pve_lxc_validate_certs | default(omit) }}"
+    proxmox_default_behavior: "{{ pve_default_behavior | default('compatibility') }}"
+    validate_certs: "{{ pve_validate_certs | default(omit) }}"
     hookscript: "{{ pve_lxc_hookscript | default(omit) }}"
     ostemplate: "{{ pve_lxc_ostemplate_storage | default('local') }}:{{ pve_lxc_ostemplate_content_type | default('vztmpl') }}/{{ pve_lxc_ostemplate_name if(pve_lxc_ostemplate_name is defined) else ( pve_lxc_ostemplate_url | urlsplit('path') | basename ) }}"
     hostname: "{{ pve_hostname }}"
@@ -88,7 +88,7 @@
           {%- endfor -%}  }
     nameserver: "{{ pve_lxc_nameserver | default(omit) }}"
     searchdomain: "{{ pve_lxc_searchdomain | default(omit) }}"
-    onboot: "{{ pve_lxc_onboot | default(omit) }}"
+    onboot: "{{ pve_onboot | default(omit) }}"
     unprivileged: "{{ pve_lxc_unprivileged | default(omit) }}"
     features: "{{ pve_lxc_features | default(omit) }}"
     timeout: "{{ pve_lxc_timeout | default(omit) }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,4 @@
 ---
 # vars file for ansible-role-proxmox-create-lxc/
+
+...


### PR DESCRIPTION
The changes proposed in this PR correspond to the suggestions that will arise from the review of [this PR](https://github.com/UdelaRInterior/ansible-role-proxmox-create-kvm/pull/11) in the companion role to maintain coherence between the globaly (`pve_`) and specificaly (`pve_lxc_`,  `pve_kvm_`) managed namespaces. Other improvements are included. 

Once this PR is merged, it will imply the release of a new version since several variables will be renamed and therefore there will be a loss of backward compatibility